### PR TITLE
Update AWS SDK from 1.9.22 to 1.9.40

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,7 +8,7 @@ import scalariform.formatter.preferences._
 
 object ApplicationBuild extends Build {
 
-  val awsSdkVersion = "1.9.22"
+  val awsSdkVersion = "1.9.40"
 
   lazy val scalariformSettings = SbtScalariform.scalariformSettings ++ Seq(
     ScalariformKeys.preferences :=


### PR DESCRIPTION
Update AWS SDK from 1.9.22 to 1.9.40. Latest SDK is 1.10.x, but it might take time to verify new interfaces. So I will make it another time.

#### Issue Type:

update library

#### Summary: 
 - Update AWS SDK for Java

Thank you.